### PR TITLE
Не отмечалось что оплата получена

### DIFF
--- a/assets/plugins/commerce/src/Payments/PaypalPayment.php
+++ b/assets/plugins/commerce/src/Payments/PaypalPayment.php
@@ -121,7 +121,7 @@ class PaypalPayment extends Payment implements PaymentInterface
         }
 
         try {
-            $response = $this->request('v2/checkout/orders/' . $_GET['token'] . '/capture');
+            $response = $this->request('v2/checkout/orders/' . $_GET['token'] . '/capture', ['intent'=>'CAPTURE']);
         } catch (Exception $e) {
             $this->modx->logEvent(0, 3, 'Order status request failed: ' . $e->getMessage(), 'Commerce PayPal Payment');
             return false;


### PR DESCRIPTION
согласно https://developer.paypal.com/docs/api/orders/v2/#error-MALFORMED_REQUEST_JSON нужно было добавить параметр ['intent'=>'CAPTURE'] в запрос иначе не отдавало данные